### PR TITLE
hotfix: fix CodeQL permissions and detect-secrets performance for PR #3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
     - cron: '0 0 * * *'  # Nightly build
   workflow_dispatch:
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write  # Required for CodeQL SARIF uploads
+
 jobs:
   lint-and-format:
     name: "🧹 Lint & Format"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,7 @@ yaml-lint = "yamllint .github/workflows/"
 action-lint = "actionlint"
 security-audit = "pip-audit --verbose"
 bandit-scan = "bandit -r framework/ -x framework/tests/ -s B101"
-detect-secrets = "detect-secrets scan --all-files"
+detect-secrets = "detect-secrets scan --exclude-files '__pycache__' --exclude-files '*.pyc' --exclude-files '*.egg-info' --exclude-files '.git' --exclude-files 'pixi.lock'"
 unit-test = "pytest framework/tests/"
 
 # Performance & Benchmarking


### PR DESCRIPTION
## 🚨 **Hotfix: CI Security Scan Failures**

**Fixes the failing security scans in PR #3 (development → main)**

### 🔧 **Issues Fixed**

#### ❌ **CodeQL SARIF Upload Failure**
- **Error**: "Resource not accessible by integration"
- **Root Cause**: Missing `security-events: write` permission
- **Fix**: Added required permissions block to CI workflow

#### ⏱️ **detect-secrets Performance Issue**  
- **Problem**: Reverted to `--all-files` causing 10+ minute scans
- **Fix**: Restored optimized exclusions for fast ~30 second scans

### 📋 **Changes Made**

**`.github/workflows/ci.yml`**:
```yaml
permissions:
  actions: read
  contents: read
  security-events: write  # Required for CodeQL SARIF uploads
```

**`pyproject.toml`**:
```toml
detect-secrets = "detect-secrets scan --exclude-files '__pycache__' ..."
```

### 🎯 **Expected Result**
After merging this hotfix:
- ✅ CodeQL security scans will upload SARIF successfully  
- ✅ detect-secrets will complete in ~30 seconds instead of 10+ minutes
- ✅ PR #3 CI checks will pass
- ✅ development → main merge can proceed

### 🚀 **Merge Priority**
**HIGH** - This blocks the main release PR #3

🤖 Generated with [Claude Code](https://claude.ai/code)