### PR TITLE
🚨 Final Fix: YAML special character parsing error on line 227

### DIFF
--- a/.github/workflows/cleanup-dev-files.yml
+++ b/.github/workflows/cleanup-dev-files.yml
@@ -205,7 +205,7 @@ jobs:
             removed_files=$(git status --porcelain | awk '{print $2}' | head -10)
             
             git add -A
-            git commit -m "chore: automated cleanup of development artifacts
+            git commit -m 'chore: automated cleanup of development artifacts
 
 Comprehensive cleanup of development files from ${{ matrix.branch }} branch:
 
@@ -230,7 +230,7 @@ This automated cleanup maintains repository hygiene by removing development
 artifacts from production branches while preserving them in feature branches.
 
 Trigger: ${{ github.event_name }}
-Workflow: CI Framework Cleanup"
+Workflow: CI Framework Cleanup'
 
             git push origin ${{ matrix.branch }}
             echo "✅ Development artifacts cleanup committed to ${{ matrix.branch }}"


### PR DESCRIPTION
## 🚨 Final YAML Syntax Fix

**Issue**: Line 227 still causes YAML parsing error due to special characters `*~`, `*.pyc`, `*.tmp` in double-quoted multiline string.

**Root Cause**: 
- YAML interprets `*` and `~` as special syntax when in double quotes
- The pattern `*~` specifically breaks YAML parsing

**Solution**: 
- Change `"..."` to `'...'` for the git commit message
- Single quotes treat ALL content as literal strings
- No special character interpretation

**This should be the FINAL fix** for the workflow syntax validation error.

After merging this PR, the cleanup workflow should execute successfully when triggered manually.

🤖 Generated with [Claude Code](https://claude.ai/code)