### PR TITLE
hotfix: Fix YAML syntax error in cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-dev-files.yml
+++ b/.github/workflows/cleanup-dev-files.yml
@@ -205,32 +205,32 @@ jobs:
             removed_files=$(git status --porcelain | awk '{print $2}' | head -10)
             
             git add -A
-            git commit -m 'chore: automated cleanup of development artifacts
+            git commit -m "chore: automated cleanup of development artifacts
 
-Comprehensive cleanup of development files from ${{ matrix.branch }} branch:
+              Comprehensive cleanup of development files from ${{ matrix.branch }} branch:
 
-AI Development Tools:
-- CLAUDE.md, .claude/, .mcp.json, .taskmaster/, ai_docs/
-- .cursor/, .aider* (Editor AI configs)
+              AI Development Tools:
+              - CLAUDE.md, .claude/, .mcp.json, .taskmaster/, ai_docs/
+              - .cursor/, .aider* (Editor AI configs)
 
-Python Development Artifacts:
-- __pycache__/, *.pyc, .pytest_cache/, htmlcov/, coverage.xml
-- .mypy_cache/, .ruff_cache/, build/, dist/, *.egg-info/
+              Python Development Artifacts:
+              - __pycache__/, *.pyc, .pytest_cache/, htmlcov/, coverage.xml
+              - .mypy_cache/, .ruff_cache/, build/, dist/, *.egg-info/
 
-Development Directories:
-- artifacts/, logs/, performance_data/, tmp/, debug/
+              Development Directories:
+              - artifacts/, logs/, performance_data/, tmp/, debug/
 
-Editor and IDE Files:
-- .vscode/settings.json, .idea/, *.code-workspace
+              Editor and IDE Files:
+              - .vscode/settings.json, .idea/, *.code-workspace
 
-Temporary and OS Files:
-- *.tmp, *.dev, .DS_Store, Thumbs.db, *~
+              Temporary and OS Files:
+              - *.tmp, *.dev, .DS_Store, Thumbs.db, *~
 
-This automated cleanup maintains repository hygiene by removing development
-artifacts from production branches while preserving them in feature branches.
+              This automated cleanup maintains repository hygiene by removing development
+              artifacts from production branches while preserving them in feature branches.
 
-Trigger: ${{ github.event_name }}
-Workflow: CI Framework Cleanup'
+              Trigger: ${{ github.event_name }}
+              Workflow: CI Framework Cleanup"
 
             git push origin ${{ matrix.branch }}
             echo "✅ Development artifacts cleanup committed to ${{ matrix.branch }}"


### PR DESCRIPTION
## Summary
- Fixed YAML syntax error in cleanup-dev-files.yml on line 227
- Changed single quotes to double quotes in multi-line commit message
- Added proper indentation for YAML compliance

## Problem
The workflow file had a YAML syntax error due to improper quoting in the multi-line commit message, causing yamllint to fail.

## Solution
- Replaced single quotes with double quotes to properly escape the multi-line string
- Fixed indentation to meet YAML standards
- Verified with yamllint that syntax errors are resolved

## Test plan
- [x] Validated with `pixi run yamllint .github/workflows/cleanup-dev-files.yml`
- [x] Confirmed no critical syntax errors remain
- [ ] Verify workflow runs successfully in CI

🤖 Generated with [Claude Code](https://claude.ai/code)