### PR TITLE
hotfix: Remove path filters to ensure cleanup triggers on all merges

### DIFF
--- a/.github/workflows/cleanup-dev-files.yml
+++ b/.github/workflows/cleanup-dev-files.yml
@@ -33,36 +33,8 @@ on:
       - main
       - master  
       - development
-    paths:
-      - 'CLAUDE.md'
-      - '.claude/**'
-      - '.taskmaster/**'
-      - '.mcp.json'
-      - 'ai_docs/**'
-      - '.cursor/**'
-      - '.aider*'
-      - '**/__pycache__/**'
-      - '**/*.pyc'
-      - '.pytest_cache/**'
-      - 'htmlcov/**'
-      - 'coverage.xml'
-      - '.mypy_cache/**'
-      - '.ruff_cache/**'
-      - 'build/**'
-      - 'dist/**'
-      - '**/*.egg-info/**'
-      - 'artifacts/**'
-      - 'logs/**'
-      - 'performance_data/**'
-      - 'tmp/**'
-      - 'debug/**'
-      - '.vscode/settings.json'
-      - '.idea/**'
-      - '*.code-workspace'
-      - '*.tmp'
-      - '*.dev'
-      - '.DS_Store'
-      - 'Thumbs.db'
+    # No path filters - cleanup runs on ANY push to protected branches
+    # This ensures cleanup happens even when development files arrive via merge
   schedule:
     # Run daily at 2 AM UTC to ensure branches stay clean
     - cron: '0 2 * * *'


### PR DESCRIPTION
## Problem
The cleanup workflow was not triggering when PRs were merged to development because it had **path filters** that only triggered when specific development files were modified. When PRs contained only workflow files or other changes, the cleanup never ran, leaving development files in protected branches.

## Root Cause
```yaml
push:
  branches: [main, master, development]
  paths: ['CLAUDE.md', '.claude/**', ...]  # ❌ This prevented triggering
```

## Solution
- **Removed path filters** from push trigger
- Cleanup now runs on **ANY push** to protected branches
- Workflow already has built-in efficiency - only commits if files found

## Result
```yaml
push:
  branches: [main, master, development]
  # ✅ No path filters - runs on all merges
```

## Benefits
- ✅ **Guaranteed cleanup** on every merge to protected branches
- ✅ **No missed cleanups** regardless of PR content
- ✅ **Efficient execution** - only commits when files actually removed
- ✅ **Maintains branch hygiene** automatically

## Test Plan
- [x] Removed restrictive path filters
- [x] Maintained conditional commit logic (only commits if files removed)
- [ ] Verify cleanup triggers on next merge to development
- [ ] Confirm development files are removed automatically

This ensures the cleanup workflow achieves its core purpose: keeping protected branches clean of development artifacts.

🤖 Generated with [Claude Code](https://claude.ai/code)