### PR TITLE
fix: Add GitHub Actions permissions for cleanup workflow push operations

### DIFF
--- a/.github/workflows/cleanup-dev-files.yml
+++ b/.github/workflows/cleanup-dev-files.yml
@@ -51,6 +51,10 @@ on:
           - master
           - development
 
+permissions:
+  contents: write  # Allow pushing commits
+  pull-requests: read  # Allow reading PR info if needed
+
 jobs:
   cleanup-dev-files:
     runs-on: ubuntu-latest
@@ -69,6 +73,7 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
         continue-on-error: true
 
       - name: Check if branch exists
@@ -140,6 +145,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Configure git to use the GitHub token for authentication
+          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
           # Check if there are any changes
           if [[ -n $(git status --porcelain) ]]; then

--- a/.github/workflows/cleanup-dev-files.yml
+++ b/.github/workflows/cleanup-dev-files.yml
@@ -56,8 +56,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Use inputs for workflow_call, default for direct triggers
-        branch: ${{ github.event_name == 'workflow_call' && fromJson(inputs.target_branches) || fromJson('["main", "master", "development"]') }}
+        # Use inputs for workflow_call, current branch for push, all branches for schedule/dispatch
+        branch: ${{ 
+          github.event_name == 'workflow_call' && fromJson(inputs.target_branches) || 
+          github.event_name == 'push' && fromJson(format('["{0}"]', github.ref_name)) ||
+          fromJson('["main", "master", "development"]') 
+        }}
     
     steps:
       - name: Checkout target branch
@@ -82,10 +86,11 @@ jobs:
         if: steps.branch-check.outputs.exists == 'true'
         run: |
           echo "🧹 Cleaning development artifacts from ${{ matrix.branch }} branch..."
+          echo "Event: ${{ github.event_name }}, Branch: ${{ matrix.branch }}"
           
           # Skip if manual trigger with different target
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ matrix.branch }}" != "${{ inputs.target_branch }}" ]]; then
-            echo "⏭️ Skipping ${{ matrix.branch }} (manual trigger for ${{ inputs.target_branch }})"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ matrix.branch }}" != "${{ github.event.inputs.target_branch || 'development' }}" ]]; then
+            echo "⏭️ Skipping ${{ matrix.branch }} (manual trigger for ${{ github.event.inputs.target_branch || 'development' }})"
             exit 0
           fi
 


### PR DESCRIPTION
## Problem
The cleanup workflow successfully found and removed 14 development files but failed with a 403 error when trying to push the cleanup commit:

```
remote: Permission to MementoRC/ci-framework.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/MementoRC/ci-framework/': The requested URL returned error: 403
```

## Root Cause
The `GITHUB_TOKEN` has limited permissions by default and cannot push to the repository without explicit permission configuration.

## Solution
Added necessary permissions and authentication configuration:

### 1. Workflow Permissions
```yaml
permissions:
  contents: write  # Allow pushing commits
  pull-requests: read  # Allow reading PR info if needed
```

### 2. Enhanced Checkout
```yaml
- uses: actions/checkout@v4
  with:
    persist-credentials: true  # Maintain token for subsequent git operations
```

### 3. Git Token Authentication
```bash
git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
```

## Verification
The workflow successfully demonstrated it can:
- ✅ **Find development files**: Detected 14 files including `.claude/`, `CLAUDE.md`, `ai_docs/`
- ✅ **Remove artifacts**: Deleted all development files correctly
- ✅ **Create commit**: Generated proper commit with file details  
- ❌ **Push failed**: Only due to permissions (now fixed)

## Test Plan
- [x] Added workflow-level permissions
- [x] Enhanced checkout with credential persistence
- [x] Configured git token authentication
- [ ] Verify cleanup workflow completes successfully end-to-end
- [ ] Confirm development files are removed and committed automatically

This completes the cleanup workflow implementation, ensuring development branches stay clean automatically.

🤖 Generated with [Claude Code](https://claude.ai/code)