### PR TITLE
fix: enable GPG signing for ci-framework-bot in CI environment

### DIFF
--- a/.github/workflows/cleanup-dev-files.yml
+++ b/.github/workflows/cleanup-dev-files.yml
@@ -169,16 +169,26 @@ jobs:
           # Import bot GPG private key for commit signing
           echo "${{ secrets.CI_BOT_GPG_KEY }}" | gpg --import --batch --yes
           gpg --list-secret-keys  # Verify import worked
-          echo "Bot GPG key imported for commit signing"
+          
+          # Configure GPG for non-interactive CI environment
+          export GPG_TTY=$(tty || echo "/dev/null")
+          echo "use-agent" >> ~/.gnupg/gpg.conf
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+          
+          # Set ultimate trust for the bot key
+          echo "${{ secrets.CI_BOT_GPG_KEY_ID }}:6:" | gpg --import-ownertrust
+          
+          echo "Bot GPG key imported and configured for CI signing"
 
       - name: Commit cleanup if files were removed
         if: steps.branch-check.outputs.exists == 'true'
         run: |
-          # Use CI bot account with GPG signing capability
+          # Use CI bot account with GPG signing capability  
           git config user.name "ci-framework-bot"
           git config user.email "ci-framework-bot@users.noreply.github.com"
           git config user.signingkey "${{ secrets.CI_BOT_GPG_KEY_ID }}"
           git config commit.gpgsign true
+          git config gpg.program gpg
 
           # Configure git to use the bot token for authentication
           git_token_url="https://x-access-token:${{ secrets.CI_BOT_TOKEN }}@github.com/"

--- a/.github/workflows/cleanup-dev-files.yml
+++ b/.github/workflows/cleanup-dev-files.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
-          token: ${{ secrets.ADMIN_TOKEN }}
+          token: ${{ secrets.CI_BOT_TOKEN }}
           persist-credentials: true
         continue-on-error: true
 
@@ -166,25 +166,26 @@ jobs:
       - name: Setup GPG for signing
         if: steps.branch-check.outputs.exists == 'true'
         run: |
-          # Import GPG private key for commit signing
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --batch --yes
-          echo "GPG key imported for commit signing"
+          # Import bot GPG private key for commit signing
+          echo "${{ secrets.CI_BOT_GPG_KEY }}" | gpg --import --batch --yes
+          gpg --list-secret-keys  # Verify import worked
+          echo "Bot GPG key imported for commit signing"
 
       - name: Commit cleanup if files were removed
         if: steps.branch-check.outputs.exists == 'true'
         run: |
-          # Use actual user account with GPG signing capability
-          git config user.name "mementorc"
-          git config user.email "claude.rc@gmail.com"
-          git config user.signingkey "C7927B4C27159961"
+          # Use CI bot account with GPG signing capability
+          git config user.name "ci-framework-bot"
+          git config user.email "ci-framework-bot@users.noreply.github.com"
+          git config user.signingkey "${{ secrets.CI_BOT_GPG_KEY_ID }}"
           git config commit.gpgsign true
 
-          # Configure git to use the ADMIN token for authentication
-          git_token_url="https://x-access-token:${{ secrets.ADMIN_TOKEN }}@github.com/"
+          # Configure git to use the bot token for authentication
+          git_token_url="https://x-access-token:${{ secrets.CI_BOT_TOKEN }}@github.com/"
           git config --global url."${git_token_url}".insteadOf "https://github.com/"
 
           # Configure GitHub CLI token
-          export GH_TOKEN="${{ secrets.ADMIN_TOKEN }}"
+          export GH_TOKEN="${{ secrets.CI_BOT_TOKEN }}"
 
           # Check if there are any changes
           if [[ -n $(git status --porcelain) ]]; then
@@ -210,7 +211,7 @@ jobs:
 
               Files removed: ${removed_files}
               
-              🤖 Automated cleanup via GitHub Actions with verified signature"
+              🤖 Automated cleanup by ci-framework-bot with verified signature"
 
             # Push cleanup branch
             git push origin "$cleanup_branch"

--- a/fresh-bot-test.tmp
+++ b/fresh-bot-test.tmp
@@ -1,0 +1,9 @@
+Fresh test for ci-framework-bot cleanup workflow
+
+This file will trigger the cleanup workflow to test:
+- CI bot account integration
+- GPG signed commits by bot
+- Auto-merge with verified signatures
+
+Test iteration: Fresh test after PR #24 merge
+Timestamp: 2025-07-26 Round 2


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Fix GPG signing failure in CI environment for ci-framework-bot
- Configure GPG for non-interactive operation with pinentry-mode loopback  
- Enable ultimate trust for bot GPG key to prevent trust issues
- Add proper GPG TTY configuration for headless environments

## Problem
The cleanup workflow was failing with "Inappropriate ioctl for device" GPG signing error because the CI environment lacks a TTY for interactive GPG operations.

## Solution
Added comprehensive GPG configuration for non-interactive CI environments:
- `pinentry-mode loopback` for headless operation
- Ultimate trust setting for bot GPG key
- Proper GPG TTY and program configuration

## Test Plan
- [x] GPG configuration tested locally
- [ ] Workflow triggers cleanup with GPG-signed commits
- [ ] Auto-merge works with verified signatures
- [ ] No signature verification blocking

This enables the ci-framework-bot to create verified GPG signatures in automated workflows.

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)